### PR TITLE
fix(AKStreamWeb/Services): 修复媒体服务器信息更新中的空引用异常

### DIFF
--- a/AKStreamWeb/Services/WebHookService.cs
+++ b/AKStreamWeb/Services/WebHookService.cs
@@ -1434,9 +1434,13 @@ namespace AKStreamWeb.Services
                     tmpMediaServer.AKStreamKeeperVersion = req.Version;
                     tmpMediaServer.ZlmBuildDateTime = req.ZlmBuildDateTime;
                     tmpMediaServer.CutMergeFilePath = req.CutMergeFilePath;
-                    mediaServer.EnableBackStroage = req.EnableBackStroage;
-                    mediaServer.BackStroageFilePath = req.BackStroageFilePath;
-                    mediaServer.BackStorageDevPath = req.BackStorageDevPath;
+                    if (mediaServer != null)
+                    {
+                        mediaServer.EnableBackStroage = req.EnableBackStroage;
+                        mediaServer.BackStroageFilePath = req.BackStroageFilePath;
+                        mediaServer.BackStorageDevPath = req.BackStorageDevPath;
+                    }
+
                     tmpMediaServer.DisksUseable.Clear();
                     if (req.DisksUseable != null && req.DisksUseable.Count > 0)
                     {


### PR DESCRIPTION
前面有判断mediaServer  是否为空,都确定为空了,后面还有直接调用的代码

- 在更新媒体服务器备份存储相关属性时增加了空引用检查
- 避免了在 mediaServer 为 null 时发生异常